### PR TITLE
Fix language metric always returning 1

### DIFF
--- a/aissert/src/aissert_lib/base.py
+++ b/aissert/src/aissert_lib/base.py
@@ -1,13 +1,33 @@
+"""Metrics for evaluating NLP question-answer pairs."""
+
 import langid
 
-def question_language_equals_answer_language_metric(q: str, a:str):
+
+def question_language_equals_answer_language_metric(q: str, a: str) -> int:
+    """Check if question and answer are in the same language.
+
+    Args:
+        q: Question text.
+        a: Answer text.
+
+    Returns:
+        1 if languages match, 0 otherwise.
+    """
     q_language, _ = langid.classify(q)
     a_language, _ = langid.classify(a)
     if q_language != a_language:
-        metric = 0
-    metric = 1
-    return metric
+        return 0
+    return 1
 
-def some_metric(input:str, output:str):
+
+def some_metric(input: str, output: str) -> float:
+    """Placeholder metric function.
+
+    Args:
+        input: Input text.
+        output: Output text.
+
+    Returns:
+        Fixed metric value of 0.8.
+    """
     return 0.8
-


### PR DESCRIPTION
## Summary
Fixes critical logic bug in `question_language_equals_answer_language_metric` that caused it to always return 1.

## Problem
The function had this logic error:
```python
if q_language != a_language:
    metric = 0
metric = 1  # Always executed, overwrites metric = 0
return metric
```

This meant the function incorrectly returned 1 even when languages didn't match.

## Changes
* Fix logic to use early return pattern
* Add module and function docstrings
* Add type annotations (int and float return types)