### PR TITLE
Fix duplicate function definitions and improve prompt generators

### DIFF
--- a/pytest-aissert/src/pytest_aissert/decorators.py
+++ b/pytest-aissert/src/pytest_aissert/decorators.py
@@ -1,32 +1,114 @@
-import pytest
+"""Decorators and prompt generators for AI-based testing."""
+
 from decorator import decorator
 
 current_report = {}
 
-def get_current_report():
+
+def get_current_report() -> dict:
+    """Get the current test report dictionary.
+
+    Returns:
+        Dictionary containing test metrics by name.
+    """
     return current_report
 
 
 def ai_test(threshold=0.5, *args, **kwargs):
-    name = kwargs['name']
+    """Decorator for AI-based test assertions with threshold.
+
+    Args:
+        threshold: Minimum metric value required to pass (default 0.5).
+        *args: Additional positional arguments.
+        **kwargs: Must include 'name' for the test identifier.
+
+    Returns:
+        Decorated function that asserts metric meets threshold.
+    """
+    name = kwargs["name"]
+
     def ai_test_dec(func, *args, **kwargs):
-        # Add functionality before the original function call
+        # Add functionality before the original function call.
         metric = func(*args, **kwargs)
-        # Add functionality after the original function call
+        # Add functionality after the original function call.
         current_report[name] = metric
         assert metric >= threshold
+
     return decorator(ai_test_dec)
+
 
 # taken from https://www.evidentlyai.com/llm-guide/llm-as-a-judge#evaluation-by-criteria
 
-def evaluate_response(response: str, question: str):
-    testing_prompt = f"Evaluate the following RESPONSE based on the given QUESTION. A complete response is one that fully addresses all parts of the question. Return one of the following labels: 'Complete' or 'Incomplete.'\nQUESTION: {question}\nRESPONSE: {response}"
 
-def reference_answer(response: str, reference: str):
-    testing_prompt = f"Compare the generated RESPONSE to the REFERENCE answer. Evaluate if the generated response correctly conveys the same meaning, even if the wording is different. Return one of these labels: 'Correct’ or 'Incorrect.'\nREFERENCE: {reference}\nRESPONSE: {response}"
+def evaluate_response(response: str, question: str) -> str:
+    """Generate prompt to evaluate response completeness.
 
-def context_assessment(context: str, question: str):
-    testing_prompt = f"Evaluate the relevance of the CONTEXT in answering the QUESTION. A relevant CONTEXT contains information that helps answer the question, even if partially. Return one of the following labels: 'Relevant', or 'Irrelevant.'\nCONTEXT: '{context}'\nQUESTION: {question}"
+    Args:
+        response: The response text to evaluate.
+        question: The question that was asked.
 
-def context_assessment(context: str, response: str):
-    testing_prompt = f"Evaluate the following RESPONSE for faithfulness to the CONTEXT. A faithful RESPONSE should only include information present in the CONTEXT, avoid inventing new details, and not contradict the CONTEXT. Return one of the following labels: 'Faithful' or 'Not Faithful'.\nCONTEXT: '{context}'\RESPONSE: {response}"
+    Returns:
+        Evaluation prompt string.
+    """
+    return (
+        f"Evaluate the following RESPONSE based on the given QUESTION. "
+        f"A complete response is one that fully addresses all parts of the question. "
+        f"Return one of the following labels: 'Complete' or 'Incomplete.'\n"
+        f"QUESTION: {question}\nRESPONSE: {response}"
+    )
+
+
+def reference_answer(response: str, reference: str) -> str:
+    """Generate prompt to compare response against reference answer.
+
+    Args:
+        response: The generated response to evaluate.
+        reference: The reference answer to compare against.
+
+    Returns:
+        Comparison prompt string.
+    """
+    return (
+        f"Compare the generated RESPONSE to the REFERENCE answer. "
+        f"Evaluate if the generated response correctly conveys the same meaning, "
+        f"even if the wording is different. "
+        f"Return one of these labels: 'Correct' or 'Incorrect.'\n"
+        f"REFERENCE: {reference}\nRESPONSE: {response}"
+    )
+
+
+def context_relevance(context: str, question: str) -> str:
+    """Generate prompt to evaluate context relevance to question.
+
+    Args:
+        context: The context text to evaluate.
+        question: The question being asked.
+
+    Returns:
+        Relevance evaluation prompt string.
+    """
+    return (
+        f"Evaluate the relevance of the CONTEXT in answering the QUESTION. "
+        f"A relevant CONTEXT contains information that helps answer the question, even if partially. "
+        f"Return one of the following labels: 'Relevant', or 'Irrelevant.'\n"
+        f"CONTEXT: '{context}'\nQUESTION: {question}"
+    )
+
+
+def context_faithfulness(context: str, response: str) -> str:
+    """Generate prompt to evaluate response faithfulness to context.
+
+    Args:
+        context: The source context text.
+        response: The response text to evaluate.
+
+    Returns:
+        Faithfulness evaluation prompt string.
+    """
+    return (
+        f"Evaluate the following RESPONSE for faithfulness to the CONTEXT. "
+        f"A faithful RESPONSE should only include information present in the CONTEXT, "
+        f"avoid inventing new details, and not contradict the CONTEXT. "
+        f"Return one of the following labels: 'Faithful' or 'Not Faithful'.\n"
+        f"CONTEXT: '{context}'\nRESPONSE: {response}"
+    )


### PR DESCRIPTION
## Summary
Fixes duplicate function definitions and incomplete implementations in pytest-aissert decorators module.

## Problems Fixed
* Two functions both named `context_assessment` with different signatures - second one overwrote the first
* Typo in f-string: `'\RESPONSE:` should be `'\nRESPONSE:`
* All prompt generator functions defined `testing_prompt` variable but never returned it

## Changes
* Rename first `context_assessment` to `context_relevance` (evaluates context relevance to question)
* Rename second `context_assessment` to `context_faithfulness` (evaluates response faithfulness to context)
* Fix escape sequence typo  
* Make all prompt functions return their prompt strings
* Add module docstring
* Add comprehensive function docstrings
* Add return type annotations (str, dict)
* Break long lines for readability and lint compliance