### PR TITLE
Clean up pytest-aissert plugin template code and add PyYAML dependency

### DIFF
--- a/pytest-aissert/pyproject.toml
+++ b/pytest-aissert/pyproject.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "pytest>=8.3.0",
-    "decorator==5.2.1"
+    "decorator==5.2.1",
+    "pyyaml>=6.0.2",
 ]
 authors = [
     { name = "Javier Torres", email = "javier@mozilla.ai" },
@@ -42,4 +43,3 @@ classifiers = [
 Repository = "https://github.com/mozilla-ai/aissert"
 [project.entry-points.pytest11]
 aissert = "pytest_aissert.plugin"
-

--- a/pytest-aissert/src/pytest_aissert/plugin.py
+++ b/pytest-aissert/src/pytest_aissert/plugin.py
@@ -1,58 +1,36 @@
-import pytest
+"""Pytest plugin for aissert AI testing framework."""
+
 import yaml
+
 import pytest_aissert.decorators as decorators
 
 
 def pytest_addoption(parser):
-    """
-    group = parser.getgroup('aissert-pytest')
-    group.addoption(
-        '--foo',
-        action='store',
-        dest='dest_foo',
-        default='2025',
-        help='Set the value for the fixture "bar".'
-    )
-    """
-    print("<<called addoption>>")
-    parser.addini('HELLO', 'Dummy pytest.ini setting')
+    """Add pytest configuration options for aissert plugin."""
+    parser.addini("HELLO", "Dummy pytest.ini setting")
 
 
 def pytest_generate_tests(metafunc):
-    """ This allows us to load tests from external files by
-    parametrizing tests with each test case found in a data_X
-    file """
+    """Load tests from external YAML files.
+
+    This allows parametrizing tests with test cases found in YAML data files.
+    """
     # TODO externalize
-    if all(x in metafunc.fixturenames for x in ['question_yaml', 'answer_yaml']):
+    if all(x in metafunc.fixturenames for x in ["question_yaml", "answer_yaml"]):
         with open("tests/questions/example_001.yaml") as q_yaml_file:
             q_yaml = yaml.safe_load(q_yaml_file)
         with open("tests/answers/example_001.yaml") as a_yaml_file:
             a_yaml = yaml.safe_load(a_yaml_file)
         metafunc.parametrize(
-            ('question_yaml', 'answer_yaml'),
+            ("question_yaml", "answer_yaml"),
             [
                 (q_yaml, a_yaml),
                 (q_yaml, a_yaml),
             ],
-            scope="session"
+            scope="session",
         )
 
 
 def pytest_sessionfinish(session, exitstatus):
-    print(f'<<< {decorators.current_report} >>>')
-
-
-
-"""
-@pytest.hookimpl(wrapper=True)
-def pytest_pyfunc_call(pyfuncitem):
-    do_something_before_next_hook_executes()
-
-    # If the outcome is an exception, will raise the exception.
-    res = yield
-
-    new_res = post_process_result(res)
-
-    # Override the return value to the plugin system.
-    return new_res"
-"""
+    """Print AI test metrics report at end of test session."""
+    print(f"<<< {decorators.current_report} >>>")

--- a/pytest-aissert/tests/test_aissert_pytest.py
+++ b/pytest-aissert/tests/test_aissert_pytest.py
@@ -1,39 +1,8 @@
-def test_bar_fixture(pytester):
-    """Make sure that pytest accepts our fixture."""
-
-    # create a temporary pytest test module
-    pytester.makepyfile("""
-        def test_sth(bar):
-            assert bar == "europython2015"
-    """)
-
-    # run pytest with the following cmd args
-    result = pytester.runpytest(
-        '--foo=europython2015',
-        '-v'
-    )
-
-    # fnmatch_lines does an assertion internally
-    result.stdout.fnmatch_lines([
-        '*::test_sth PASSED*',
-    ])
-
-    # make sure that we get a '0' exit code for the testsuite
-    assert result.ret == 0
-
-
-def test_help_message(pytester):
-    result = pytester.runpytest(
-        '--help',
-    )
-    # fnmatch_lines does an assertion internally
-    result.stdout.fnmatch_lines([
-        'aissert-pytest:',
-        '*--foo=DEST_FOO*Set the value for the fixture "bar".',
-    ])
+"""Tests for pytest-aissert plugin."""
 
 
 def test_hello_ini_setting(pytester):
+    """Test that HELLO ini setting can be configured and accessed."""
     pytester.makeini("""
         [pytest]
         HELLO = world
@@ -50,12 +19,14 @@ def test_hello_ini_setting(pytester):
             assert hello == 'world'
     """)
 
-    result = pytester.runpytest('-v')
+    result = pytester.runpytest("-v")
 
     # fnmatch_lines does an assertion internally
-    result.stdout.fnmatch_lines([
-        '*::test_hello_world PASSED*',
-    ])
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_hello_world PASSED*",
+        ]
+    )
 
     # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0


### PR DESCRIPTION
## Summary
Removes dead template code from pytest-aissert plugin and adds missing PyYAML dependency that was causing import errors.

## Changes
* Add PyYAML>=6.0 to pytest-aissert dependencies (was imported but not declared)
* Remove commented --foo option template code from pytest_addoption
* Remove debug print statement
* Remove commented pytest_pyfunc_call hook template
* Remove 2 failing tests (test_bar_fixture, test_help_message) that tested non-existent --foo option
* Keep test_hello_ini_setting which tests actual working functionality
* Add module and function docstrings

## Testing
* test_hello_ini_setting now passes
* Plugin loads without import errors