### PR TITLE
Add project documentation and update README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the team at mozilla.ai. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to `aissert`
+
+Thank you for your interest in contributing to the `aissert` project!
+We welcome contributions from everyone and are grateful for your help in making this project better.
+
+By contributing to this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+---
+
+## **Guidelines for Contributions**
+
+### Ground Rules
+
+- Review issue discussion fully before starting work. Engage in the thread first when an issue is under discussion.
+- PRs must build on agreed direction where ones exist. If there is no agreed direction, seek consensus from the core maintainers.
+- PRs with "drive-by" unrelated changes or untested refactors will be closed.
+- Untested or failing code is not eligible for review.
+- PR description **must** follow the PR template and explain **what** changed, **why**, and **how to test**.
+- Links to related issues are required.
+- Duplicate PRs will be automatically closed.
+- Only have 1-2 PRs open at a time. Any further PRs will be closed.
+
+**Maintainers reserve the right to close issues and PRs that do not align with the library roadmap.**
+
+### Code Clarity and Style
+
+- **Readability first:** Code must be self-documenting—if it is not self-explanatory, it should include clear, concise comments where logic is non-obvious.
+- **Consistent Style:** Follow existing codebase style (e.g., function naming, Python conventions)
+- **No dead/debug code:** Remove commented-out blocks, leftover debug statements, unrelated refactors
+- Failure modes must be documented and handled with robust error handling.
+
+### Testing Requirements
+
+- **Coverage:** All new functionality must include unit tests covering both happy paths and relevant edge cases.
+- **Passing tests:** All linting and formatting checks must pass (see below on how to run).
+- **No silent failures:** Tests should fail loudly on errors. No placeholder tests.
+
+### Scope and Size
+
+- **One purpose per PR:** No kitchen-sink PRs mixing bugfixes, refactors, and features.
+- **Small, reviewable chunks:** If your PR is too large to review in under 30 minutes, break it up into chunks.
+- Each chunk must be independently testable and reviewable
+- If you can't explain why it can't be split, expect an automatic request for refactoring.
+- Pull requests that are **large** (>500 LOC changed) or span multiple subsystems will be closed with automatic requests for refactoring.
+- If the PR is to implement a new feature, please first make a GitHub issue to suggest the feature and allow for discussion. We reserve the right to close feature implementations and request discussion via an issue.
+
+## How to Contribute
+
+We encourage contributions via GitHub pull requests.
+
+### **Browse Existing Issues** 🔍
+- Check the Issues page to see if there are any tasks you'd like to tackle.
+- Look for issues labeled **`good first issue`** if you're new to the project—they're a great place to start.
+
+### **Report Issues** 🐛
+- **Bugs:** Please use our Bug Report template to provide clear steps to reproduce and environment details.
+- **Search First:** Before creating a new issue, please search existing issues to see if your topic has already been discussed.
+- Provide as much detail as possible, including the steps to reproduce the issue and expected vs. actual behavior.
+
+### **Suggest Features** 🚀
+- **Features:** Please use our Feature Request template to describe the problem your idea solves and your proposed solution.
+- Share why the feature is important and any alternative solutions you've considered.
+- If the PR is to implement a new feature, please first make a GitHub issue to suggest the feature and allow for discussion.
+
+### Requirements
+
+* [uv](https://docs.astral.sh/uv/) - Dependency management
+* [pre-commit](https://pre-commit.com/) - Code quality checks
+
+### **Submit Pull Requests** 💻
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your forked repository to your local machine.
+    ```bash
+    git clone https://github.com/{YOUR_GITHUB_USERNAME}/aissert.git
+    cd aissert
+    ```
+3. **Create a new branch** for your changes based on the `main` branch.
+    ```bash
+    git checkout main
+    git pull origin main
+    git checkout -b your-feature-or-bugfix-branch
+    ```
+4. **Install dependencies:**
+   ```bash
+   make install
+   ```
+5. **Make your changes** to the appropriate package.
+6. **Format and Lint:** Ensure your code passes linting and formatting checks:
+   ```bash
+   make lint
+   ```
+7. **Add Unit Tests:** All new features and bug fixes should be accompanied by relevant unit tests. Run tests with:
+   ```bash
+   make test
+   ```
+8. **Commit your changes** with a clear and descriptive message.
+9. **Push your branch** to your forked repository.
+10. **Open a Pull Request** from your branch to the `main` branch of the upstream `mozilla-ai/aissert` repository.
+    - Follow the [Guidelines for Contributions](#guidelines-for-contributions)
+    - Ensure your branch is up-to-date with the main branch before submitting the PR
+    - Please add as much detail as possible, including how to test the changes
+    - Reference the relevant GitHub issue in your PR summary
+
+## Security Vulnerabilities
+
+If you discover a security vulnerability, please **DO NOT** open a public issue. Report it responsibly by contacting mozilla.ai.
+
+## License
+
+By contributing, you agree that your contributions will be licensed as described in [LICENSE](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,374 @@
+
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,67 @@
 
 A lightweight testing suite for AI applications to ensure your generative outputs behave as expected.
 
+## Monorepo Structure
+
+This repository contains multiple related packages:
+
+| Package                             | Description                                 |
+|-------------------------------------|---------------------------------------------|
+| [aissert](./aissert/)               | Core library for AI metrics and assertions  |
+| [aissert-cli](./aissert-cli/)       | CLI tool for running AI security tests      |
+| [example-pkg](./example-pkg/)       | Example package demonstrating aissert usage |
+| [pytest-aissert](./pytest-aissert/) | Pytest plugin for AI testing                |
+| [qa_bot](./qa_bot/)                 | Example QA chatbot with AI testing          |
 
 ## Installation
 
-1. Create the virtual environment
+This project uses [uv](https://docs.astral.sh/uv/) for dependency management.
+
+```bash
+# Install UV
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install all workspace dependencies
+uv sync --dev
+# or via Makefile
+make install
 ```
-python3 -m venv .venv source .venv/bin/activate
+
+## Development
+
+Common development tasks are available via the Makefile:
+
+```bash
+# Install dependencies
+make install
+
+# Run linting and formatting
+make lint
+
+# Run all tests
+make test
+
+# Run tests for specific package
+make test-pytest-aissert
+make test-qa-bot
+make test-example-pkg
+
+# Clean build artifacts
+make clean
 ```
-2. Install dependencies
-```
-pip install -r requirements.txt
-``
+
+## Contributing
+
+We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get started.
+
+## Security
+
+For information on reporting security vulnerabilities, please see our [Security Policy](SECURITY.md).
+
+## Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## License
+
+This project is licensed under the Mozilla Public License 2.0 (MPL-2.0). See the [LICENSE](LICENSE) file for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We at [Mozilla AI](https://www.mozilla.ai/) take the security of our projects seriously. We appreciate your efforts to responsibly disclose security vulnerabilities.
+
+This document outlines the process for reporting vulnerabilities in `aissert`.
+
+### Supported Versions
+
+The following versions are currently supported for security updates:
+
+| Version | Supported          |
+|---------|---------------------|
+| 0.1.x   | :white_check_mark: |
+
+**Please ensure you are using a supported version when reporting a vulnerability.**
+
+## Reporting a Vulnerability
+
+**Please DO NOT open a public GitHub issue.**
+
+To report a security vulnerability, please send a detailed email to: [security@mozilla.ai](mailto:security@mozilla.ai)
+
+Please include the following information in your report:
+
+1.  **Project Name and Version:** Specify which project (`mozilla-ai/aissert`) and which version(s) are affected.
+2.  **Vulnerability Description:** A clear and concise description of the vulnerability.
+3.  **Steps to Reproduce:** Detailed steps to reproduce the vulnerability, including any necessary code, configuration, or environment details.
+4.  **Impact:** Describe the potential impact of the vulnerability (e.g., data breach, denial of service, privilege escalation).
+5.  **Proof of Concept (Optional but Recommended):** Any proof-of-concept code or demonstration that helps us understand and verify the vulnerability. If you have this in a repository please ensure it is private, we can privately discuss granting access to specific Mozilla AI employees for review.
+6.  **Your Contact Information (Optional):** If you wish to be credited for your discovery, please provide your name/handle and preferred contact method.
+
+### Our Commitment
+
+* We will acknowledge receipt of your report within 2 business days.
+* We will investigate the report promptly and provide an initial assessment within 5 business days.
+* We will keep you informed of our progress throughout the vulnerability resolution process.
+* Once the vulnerability is patched, we will notify you and, with your permission, include your name in our release notes or security advisory as a thank you for your responsible disclosure.
+* We follow a 'coordinated disclosure' approach, meaning we aim to have a fix available before public disclosure.
+
+### Public Disclosure
+
+Please allow us a reasonable amount of time to address the vulnerability before public disclosure. We request that you do not disclose the vulnerability publicly until we have confirmed a fix is available and have agreed on a disclosure timeline.
+
+Our typical disclosure timeline for critical issues is up to 30 days from the initial report, but this may vary depending on complexity.
+
+### Scope
+
+This security policy applies to all components of [aissert](https://github.com/mozilla-ai/aissert).
+
+Thank you for helping us keep our projects secure for everyone.


### PR DESCRIPTION
## Summary

This PR adds comprehensive project documentation and updates the root README.

### New Files
- **CODE_OF_CONDUCT.md**: Contributor Covenant code of conduct
- **CONTRIBUTING.md**: Contribution guidelines and workflow (adapted from mozilla-ai/mcpd)
- **SECURITY.md**: Security vulnerability reporting process (adapted from mozilla-ai/mcpd)
- **LICENSE**: Mozilla Public License 2.0 (MPL-2.0, matching existing license in pytest-aissert)

### README Updates
- Fixed broken code blocks (missing newline between commands, incomplete backticks)
- Added Monorepo Structure section with table format for better readability
- Replaced pip/requirements.txt installation instructions with uv workspace setup
- Added Development section documenting Makefile commands
- Added references to CONTRIBUTING.md, SECURITY.md, and CODE_OF_CONDUCT.md

### Related
This addresses similar README issues identified in PR #4 by @j-klawson. The main differences are:
- Uses uv workspace instead of requirements.txt (as implemented in PR #6)
- Adds comprehensive project documentation files
- Documents Makefile usage for development tasks

Refs: https://github.com/mozilla-ai/aissert/pull/4